### PR TITLE
fixed bug, where timers freeze if you have more than one on a page

### DIFF
--- a/js/jquery.t-countdown.js
+++ b/js/jquery.t-countdown.js
@@ -125,7 +125,7 @@
 			days = Math.floor(Math.abs(diffSecs/60/60/24)%7);
 			weeks = Math.floor(Math.abs(diffSecs/60/60/24/7));
 		}
-		style = $.data($(this)[0], 'style');
+    style = $.data($this[0], 'style');
 
 		$this.dashTminusChangeTo(id, style + '-seconds_dash', secs, duration ? duration : 500);
 		$this.dashTminusChangeTo(id, style + '-minutes_dash', mins, duration ? duration : 1000);


### PR DESCRIPTION
As the title says, when you have two timers on one page, e.g. one as widget and one via shortcode, both freeze.
After applying my fix, the correct selectors will be used to update the numbers.