### PR TITLE
Prevent errors when $(this) isn't an array

### DIFF
--- a/js/jquery.t-countdown.js
+++ b/js/jquery.t-countdown.js
@@ -26,6 +26,9 @@
 
 (function($){
 	$.fn.tminusCountDown = function (options) {
+		if ($(this)[0] == undefined)
+			return;
+
 		config = {};
 		$.extend(config, options);
 		tminusTargetTime = this.setTminustminusTargetTime(config);


### PR DESCRIPTION
Without this correction, it would fail on the first $.data call, whenever $(this) wasn't an array. And then, the rest of JQuery code on the webpage wouldn't run.

Everything else works perfectly fine about the plugin and the webpage with this modification.